### PR TITLE
use fixed version for foundry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-5ac78a9cd4b94dc53d1fe5e0f42372b28b5a7559
 
       - name: Run Forge build
         run: |


### PR DESCRIPTION
Using June 2nd build of foundry, since latest version might be purged